### PR TITLE
Added support for options when defining transforms

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -163,7 +163,10 @@ function Bro(bundleFile) {
     var bundle = browserify(browserifyOptions);
 
     _.forEach(bopts.transform, function(t) {
-      bundle.transform(t);
+      if (!Array.isArray(t)) {
+        t = [t];
+      }
+      bundle.transform.apply(bundle, t);
     });
 
 


### PR DESCRIPTION
`bundle.transform` has [two arguments](https://github.com/substack/node-browserify#btransformopts-tr).

With this, you can specify options with a transform while still being able to specify the transform name/function like normal:

``` js
karma.set({
    frameworks: ["browserify"],
    // ...
    browserify: {
        transform: [
            'coffeeify',
            ['envify'],
            [{global: true}, 'debowerify']
        ]
        // ...
    },
    // ...
});
```
