### PR TITLE
Fix bug when no test files exist and browserify in debug mode

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -240,7 +240,9 @@ function Bro(bundleFile) {
     function updateSourceMap(file, content) {
       if (debug) {
         var map = convert.fromSource(content);
-        file.sourceMap = map.sourcemap;
+        if(map) {
+            file.sourceMap = map.sourcemap;
+        }
       }
     }
 


### PR DESCRIPTION
If you run karma while you don't have yet any test files, and you configured browserify to run in debug mode, you will get a nasty exception saying that map is null and doest not have a sourcemap property.
