### PR TITLE
Make watchify a regular dependency and downgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "bugs": "https://github.com/Nikku/karma-bro/issues",
   "dependencies": {
     "convert-source-map": "~0.3.3",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "watchify": "^0.10.2"
   },
   "devDependencies": {
     "grunt": "~0.4.4",
@@ -37,7 +38,6 @@
     "tsify": "^0.1.4"
   },
   "peerDependencies": {
-    "karma": ">=0.10",
-    "watchify": ">=0.6"
+    "karma": ">=0.10"
   }
 }


### PR DESCRIPTION
As described in #9 watchify v1 introduces breaking changes. I also don't think it's a peerDep. To me peers are used by frameworks — things where the framework calls your module and not the other way around. So while a browserify transform is definitely a peer to browserify I don't see watchify as a peer to karma-bro. Especially because browserify is not a peer to watchify. If the idea is to allow a user to use a single browserify module across karma-bro and a build tool, that's not possible. 

Closes #9
