### PR TITLE
Leave watchify as peer but restrict watchify version to ^0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "peerDependencies": {
     "karma": ">=0.10",
-    "watchify": ">=0.6"
+    "watchify": "^0.10.2"
   }
 }


### PR DESCRIPTION
Alternate to #10 if you decide watchify should stay a peer

Closes #9
