### PR TITLE
feat(plug-in): close watchers when karma exits

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -85,6 +85,7 @@ function Bro(bundleFile) {
 
 
     emitter.on('exit', function(done) {
+      getBundle(config).close();
       bundleFile.remove();
       log.debug('bundle file cleaned up');
       done();


### PR DESCRIPTION
Relevant when using the karma API since the watchers aren't killed with the process
