### PR TITLE
fix(plug-in): use minimatch to compare patterns

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -2,7 +2,8 @@
 
 var browserify = require('browserify'),
     watchify = require('watchify'),
-    convert = require('convert-source-map');
+    convert = require('convert-source-map'),
+    minimatch = require('minimatch');
 
 var path = require('path');
 
@@ -32,10 +33,6 @@ function Bro(bundleFile) {
     var files = config.files,
         preprocessors = config.preprocessors;
 
-    // TODO(Nikku): properly compare patterns from config.files and
-    // config.preprocessors with ['browserify'] specified. Is this even
-    // possible on glob expressions?
-
     // list of patterns using our preprocessor
     var patterns = _.reduce(preprocessors, function(matched, val, key) {
       if (val.indexOf('browserify') !== -1) {
@@ -46,7 +43,9 @@ function Bro(bundleFile) {
 
     // first file being preprocessed
     var file = _.find(files, function(f) {
-      return patterns.indexOf(f.pattern) !== -1;
+      return _.any(patterns, function(p) {
+        return minimatch(f.pattern, p);
+      });
     });
 
     var idx = 0;

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
   },
   "bugs": "https://github.com/Nikku/karma-bro/issues",
   "dependencies": {
+    "browserify": "^5.10.1",
     "convert-source-map": "~0.3.3",
     "lodash": "~2.4.1",
-    "watchify": "^1.0.1",
-    "browserify": "^5.10.1"
+    "minimatch": "^1.0.0",
+    "watchify": "^1.0.1"
   },
   "devDependencies": {
     "brfs": "^1.2.0",

--- a/test/spec/pluginSpec.js
+++ b/test/spec/pluginSpec.js
@@ -177,6 +177,53 @@ describe('bro', function() {
 
       });
 
+      it('should insert bundle file before more-specific preprocessed pattern', function() {
+
+        // given
+        var config = createConfig({
+          files: [
+            { pattern: 'vendor/external.js' },
+            { pattern: 'foo/*Spec.js' }
+          ],
+          preprocessors: {
+            'foo/*.js': [ 'browserify' ]
+          }
+        });
+
+        // when
+        createPlugin(config);
+
+        // expect bundle file to be inserted at pos=1
+        // since foo/*Spec.js matches the foo/*.js glob
+        expect(config.files).to.deep.eql([
+          { pattern : 'vendor/external.js' },
+          { pattern : bundle.location, served : true, included : true, watched : true },
+          { pattern : 'foo/*Spec.js' }
+        ]);
+
+      });
+
+      it('should not insert bundle file before less-specific preprocessed pattern', function() {
+
+        // given
+        var config = createConfig({
+          files: [
+            { pattern: 'vendor/external.js' },
+            { pattern: 'foo/*.js' }
+          ],
+          preprocessors: {
+            'foo/*Spec.js': [ 'browserify' ]
+          }
+        });
+
+        // when
+        createPlugin(config);
+
+        // then
+        expect(config.files[0].pattern).to.eql(bundle.location);
+
+      });
+
     });
 
 


### PR DESCRIPTION
When figuring out where to insert the built bundle file, karma-bro would exactly compare the patterns from config.preprocessors against those in config.files (using indexOf). This behaves incorrectly when a more general glob pattern is specified in the preprocessor.

This commit fixes this by using minimatch to compare globs when figuring out where to insert the bundle.

For example, given the following config: 

``` javascript
config.set({
  preprocessors: {
    'test/*.js': [‘browserify’]
  },

  files: [
    'vendor/external.js',
    'test/*Spec.js'
  ]
});
```

karma-bro will now insert the bundle in between the two files specified, because while `test/*Spec.js === test/*.js` returns `false`,  `minimatch(‘test/*Spec.js’, ‘test/*.js’)` returns `true`.
