### PR TITLE
Update to browserify@6

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-release": "~0.7.0",
     "karma": "^0.12.19",
     "load-grunt-tasks": "~0.4.0",
-    "tsify": "^0.3.1"
+    "tsify": "^0.5.0"
   },
   "peerDependencies": {
     "karma": ">=0.10"


### PR DESCRIPTION
Waiting on https://github.com/smrq/tsify/issues/14. tsify dependency will need to be updated to avoid peerDep warnings. 
