### PR TITLE
Pass all browserify options from karma.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,7 @@ Look at the [example directory](https://github.com/Nikku/karma-bro/tree/master/e
 
 ### Browserify Config
 
-The way Bro creates browserified test bundles can be tuned through the `browserify` configuration property. The following [configuration options](https://github.com/substack/node-browserify#var-b--browserifyfiles-or-opts) are supported:
-
-*   extensions
-*   builtins
-*   basedir
-*   commondir
-*   transform
-*   plugin
+The way Bro creates browserified test bundles can be tuned through the `browserify` configuration property. The object is used as the [`opts` parameter](https://github.com/substack/node-browserify#var-b--browserifyfiles-or-opts).
 
 
 #### Generate Source Maps

--- a/lib/bro.js
+++ b/lib/bro.js
@@ -120,9 +120,7 @@ function Bro(bundleFile) {
 
     var bopts = config.browserify || {};
 
-    var browserifyOptions = _.extend({}, watchify.args, _.pick(bopts, [
-      'extensions', 'builtins', 'basedir', 'commondir', 'debug'
-    ]));
+    var browserifyOptions = _.extend({}, watchify.args, bopts);
 
     var w = watchify(browserify(browserifyOptions));
 


### PR DESCRIPTION
Browserify has a lot of configuration options, including those passed to `module-deps` and `browser-pack`. There is no reason to filter the options unless one is known not to work.
