### PR TITLE
chore(deps): Update to watchify@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "convert-source-map": "~0.3.3",
     "lodash": "~2.4.1",
     "minimatch": "^1.0.0",
-    "watchify": "^1.0.1"
+    "watchify": "^2.1.1"
   },
   "devDependencies": {
     "brfs": "^1.2.0",


### PR DESCRIPTION
There is an issue with certain version of watchify below 2.1.1 on the osx 10.10
