### PR TITLE
bundlePreprocessor - testPreprocessor race #57

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -194,8 +194,8 @@ function Bro(bundleFile) {
       if (cb) {
         w.once('bundled', cb);
       }
-
-      rebuild();
+      if (testFilePreprocessorCalled)
+        rebuild();
     }
 
 
@@ -274,9 +274,11 @@ function Bro(bundleFile) {
    * A processor that preprocesses commonjs test files which should be
    * delivered via browserify.
    */
+  var testFilePreprocessorCalled = false
   function testFilePreprocessor() {
 
     return function(content, file, done) {
+      testFilePreprocessorCalled = true
       b.bundleFile(file, function(err, content) {
         done(content && content.toString());
       });


### PR DESCRIPTION
Ensures that bundle does not happen before the testFilePreprocessor is called. Fixes a race condition where buy bundlepreprocessor fires a browserify bundle before the testFiles have been read in. resolves #57 
