### PR TITLE
fix(plug-in): apply transforms and plugins on every rebuild

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -138,24 +138,6 @@ function Bro(bundleFile) {
 
     var w = watchify(browserify(browserifyOptions));
 
-    _.forEach(bopts.plugin, function(p) {
-      // ensure we can pass plugin options as
-      // the first parameter
-      if (!Array.isArray(p)) {
-        p = [ p ];
-      }
-      w.plugin.apply(w, p);
-    });
-
-    _.forEach(bopts.transform, function(t) {
-      // ensure we can pass transform options as
-      // the first parameter
-      if (!Array.isArray(t)) {
-        t = [ t ];
-      }
-      w.transform.apply(w, t);
-    });
-
     // test if we have a prebundle function
     if (bopts.prebundle && typeof bopts.prebundle === 'function') {
       bopts.prebundle(w);
@@ -206,6 +188,24 @@ function Bro(bundleFile) {
       log.debug('bundling');
 
       w.reset();
+
+      _.forEach(bopts.plugin, function(p) {
+        // ensure we can pass plugin options as
+        // the first parameter
+        if (!Array.isArray(p)) {
+          p = [ p ];
+        }
+        w.plugin.apply(w, p);
+      });
+
+      _.forEach(bopts.transform, function(t) {
+        // ensure we can pass transform options as
+        // the first parameter
+        if (!Array.isArray(t)) {
+          t = [ t ];
+        }
+        w.transform.apply(w, t);
+      });
 
       files.forEach(function(f) {
         w.require(f, { expose: path.relative(config.basePath, f) });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "bugs": "https://github.com/Nikku/karma-browserify/issues",
   "dependencies": {
-    "browserify": "~7.0.0",
+    "browserify": "~7.0.1",
     "convert-source-map": "~0.3.3",
     "js-string-escape": "^1.0.0",
     "lodash": "~2.4.1",


### PR DESCRIPTION
So with browserify 7.0.1 manually resetting the bundle requires the transforms to be reapplied. Pretty sure the offending change is:

https://github.com/substack/node-browserify/compare/7.0.0...7.0.1#diff-168726dbe96b3ce427e7fedce31bb0bcL274

Not sure whether resetting is still necessary @Nikku 
