### PR TITLE
Fix for browserify 7.0.2

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -205,7 +205,13 @@ function Bro(bundleFile) {
 
       log.debug('bundling');
 
-      w.reset();
+      if (w._bundled) {
+        var recorded = w._recorded;
+        w.reset();
+        recorded.forEach(function (tr) {
+          if (tr.transform) w.pipeline.write(tr);
+        });
+      }
 
       files.forEach(function(f) {
         w.require(f, { expose: path.relative(config.basePath, f) });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "bugs": "https://github.com/Nikku/karma-browserify/issues",
   "dependencies": {
-    "browserify": "~7.0.0",
+    "browserify": "~7.0.2",
     "convert-source-map": "~0.3.3",
     "js-string-escape": "^1.0.0",
     "lodash": "~2.4.1",

--- a/test/spec/pluginSpec.js
+++ b/test/spec/pluginSpec.js
@@ -605,6 +605,67 @@ describe('bro', function() {
       });
     });
 
+
+    it('should persist transforms', function(done) {
+      var bundleFile = createFile(bundle.location);
+      var testFile = createFile('test/fixtures/transform.js');
+      var plugin = createPlugin({
+        browserify: {
+          transform: [ 'brfs' ],
+          // Hook into bundler/pipeline events for success/error
+          prebundle: function(bundle) {
+            // After first bundle
+            bundle.once('bundled', function (err) {
+              // Fail if there was an error
+              if (err) return done(err);
+              // Set up error/success handlers
+              bundle.on('bundle', function (pipeline) {
+                pipeline
+                  .on('error', done)
+                  .on('end', function() {
+                    expect(bundleFile.bundled).to.contain("module.exports.text = '<' + \"HALLO\" + '>'");
+                    done();
+                  });
+              });
+              // Rebundle
+              plugin.preprocess(bundleFile, [ testFile ], function() {});
+            });
+          }
+        }
+      });
+      // Initial bundle
+      plugin.preprocess(bundleFile, [ testFile ], function() {});
+    });
+
+
+    it('should persist plugins', function(done) {
+      var bundleFile = createFile(bundle.location);
+      var testFile = createFile('test/fixtures/plugin.ts');
+      var plugin = createPlugin({
+        browserify: {
+          plugin: [ ['tsify', { removeComments: true } ] ],
+          // Hook into bundler/pipeline events for success/error
+          prebundle: function(bundle) {
+            // After first bundle
+            bundle.once('bundled', function (err) {
+              // Fail if there was an error
+              if (err) return done(err);
+              // Set up error/success handlers
+              bundle.on('bundle', function (pipeline) {
+                pipeline
+                  .on('error', done)
+                  .on('end', done);
+              });
+              // Rebundle
+              plugin.preprocess(bundleFile, [ testFile ], function() {});
+            });
+          }
+        }
+      });
+      // Initial bundle
+      plugin.preprocess(bundleFile, [ testFile ], function() {});
+    });
+
   });
 
 });


### PR DESCRIPTION
Browserify writes transforms (and transforms added by plugins) through the build pipeline now. Resetting the bundler if it hasn't been bundled will create a new pipeline without any of those transforms. Additionally, calling `b.reset()` after bundling will create a new pipeline without the transforms. Calling `b.bundle()` again (rather than resetting) handles re-adding transforms automatically, but it would also add all of the recorded files again (which we handle with `b.require()`). The solution is to conditionally reset only if the bundler has been bundled, and to re-add any existing transforms manually after the reset.
