### PR TITLE
Fix double bundling on file change

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -165,7 +165,12 @@ function Bro(bundleFile) {
     if (config.autoWatch) {
       log.info('registering rebuild (autoWatch=true)');
 
-      w.on('update', function() {
+      w.on('update', function(updated) {
+        for (var i = 0; i < updated.length; i++) {
+          if (files.indexOf(updated[i]) !== -1) {
+            return log.debug('skipping update');
+          }
+        };
         log.debug('files changed');
         deferredBundle();
       });


### PR DESCRIPTION
Karma already triggers a `deferredBundle()` if it detects a file change to a main file. A rebuild should only happen if watchify sends an update for a file **not** handled by the karma watcher. Since it's all or nothing, we only have to check until we find the first file that **is** handled by karma. (fwiw tests pass in browserify-7.0.2 branch)
