### PR TITLE
feat(framework) Return bundle as injected framework value

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -110,6 +110,8 @@ function Bro(bundleFile) {
     // add bundle file to the list of files defined in the
     // configuration. be smart by doing so.
     addBundleFile(bundleFile, config);
+
+    return b;
   }
 
   framework.$inject = [ 'emitter', 'config', 'logger' ];


### PR DESCRIPTION
This patch returns the browserify bundle instance so other injected services
may make use of it. For example, a karma reporter may inject the browserify
framework so it can track bundle build times. Currently the framework
is `undefined` as far as the injector is concerned.
