### PR TITLE
fix(plug-in): fix path for checking/logging removed files

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -221,8 +221,8 @@ function Bro(bundleFile) {
         recorded.forEach(function(e) {
           // we remove missing files on the fly
           // to cope with bundle internals missing
-          if (e.file && !fs.existsSync(e.file)) {
-            log.debug('removing missing file', path.relative(config.basePath, e.file));
+          if (e.file && !fs.existsSync(path.resolve(config.basePath, e.file))) {
+            log.debug('removing missing file', e.file);
           } else {
             w.pipeline.write(e);
           }

--- a/test/integration/single-run.conf.js
+++ b/test/integration/single-run.conf.js
@@ -8,15 +8,17 @@ module.exports = function(karma) {
   karma.set({
     files: [
       'vendor/external.js',
+      'test/aSpec.js',
+      'test/xxaSpec.js',
       'test/externalSpec.js'
     ],
 
     preprocessors: {
-      'test/externalSpec.js': [ 'browserify' ]
+      'test/*.js': [ 'browserify' ]
     },
 
     reporters: [],
 
-    logLevel: 'ERROR',
+    logLevel: 'ERROR'
   });
 };

--- a/test/restorable-file.js
+++ b/test/restorable-file.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var fs = require('fs');
+
+function RestorableFile(location) {
+
+  var contents;
+
+  function update(newContents) {
+    fs.writeFileSync(location, newContents);
+  }
+
+  function load() {
+    contents = fs.readFileSync(location);
+  }
+
+  this.load = load;
+  this.update = update;
+
+  this.remove = function() {
+    fs.unlinkSync(location);
+  };
+
+  this.restore = function() {
+    update(contents);
+  };
+}
+
+module.exports = RestorableFile;

--- a/test/spec/logger-factory.js
+++ b/test/spec/logger-factory.js
@@ -57,33 +57,4 @@ function LoggerFactory() {
   };
 }
 
-
-var fs = require('fs');
-
-function File(location) {
-
-  var contents;
-
-  function write(newContents) {
-    fs.writeFileSync(location, newContents);
-  }
-
-  function load() {
-    contents = fs.readFileSync(location);
-  }
-
-  this.load = load;
-  this.update = write;
-
-  this.remove = function() {
-    fs.unlinkSync(location);
-  };
-
-  this.restore = function() {
-    write(contents);
-  };
-}
-
-
-module.exports.File = File;
-module.exports.LoggerFactory = LoggerFactory;
+module.exports = LoggerFactory;


### PR DESCRIPTION
@nikku take a look and make sure this works for you on Linux. Basically the code for checking for removed files was assuming that the browserify recorder would report absolute paths. In reality it reports relative paths, perhaps because of 399fa6b29eece56eb538f4b4b1dd5cc4d9c6d99b.

Closes #75