### PR TITLE
Make karma-browserify work in Node v0.8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: node_js
-node_js: '0.10'
+node_js:
+  - '0.10'
+  - '0.8'
+
+sudo: false
 
 script:
   - npm test
 
 before_install:
+  - npm install -g npm@~1.4.6
   - npm install -g grunt-cli
 
 deploy:

--- a/lib/bundle-file.js
+++ b/lib/bundle-file.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs'),
     path = require('path'),
-    os = require('os'),
+    os = require('os-shim'),
     crypto = require('crypto');
 
 /**

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "js-string-escape": "^1.0.0",
     "lodash": "~2.4.1",
     "minimatch": "^1.0.0",
+    "os-shim": "~0.1.2",
     "watchify": "~2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Use the [`os-shim` module](https://github.com/AdesisNetlife/node-os-shim) which provides shims for methods like `os.tmpdir()`.

Over at [`request`](https://github.com/request/request) we still want to support Node v0.8.x.  This provides a transparent way to do so.  Here's a current failing Travis build due to missing `os.tmpdir()` method:

https://travis-ci.org/request/request/builds/48310988