### PR TITLE
Add code to pass watchify args from config file

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -162,8 +162,12 @@ function Bro(bundleFile) {
       log.warn('The prebundle hook got removed in favor of configure');
     }
 
+    if ('watchify' in browserifyOptions) {
+      log.warn('Add watchify configuration in its own root level node, not as a child of browserify');
+    }
 
-    var w = watchify(browserify(browserifyOptions));
+
+    var w = watchify(browserify(browserifyOptions), config.watchify || {});
     w.setMaxListeners(Infinity);
 
     _.forEach(bopts.plugin, function(p) {


### PR DESCRIPTION
I couldn't determine a good way to test this. It's a pretty simple change ultimately so I hope that's okay. I did test manually in a project I have that uses a vagrant box.