### PR TITLE
Override browserify version using a new `createBrowserify` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,32 @@ You'll also need to use the `'prebundle'` event for full control over the order 
 
 Note that transforms must only be added once.
 
+#### Using a different version of browserify
+
+This plugin ships with a specific version of browserify, which is used by default. You can optionally configure a different browserify version.
+
+First you will have to add browserify as a dependency to your own project. For example: `npm install browserify@^12.0.0 --save-dev` _(this command modifies `package.json` for you)_.
+
+You should then set the `createBrowserify` option:
+
+```javascript
+    browserify: {
+      createBrowserify: require('browserify')
+    }
+```
+
+If the `createBrowserify` option is set, its value must be a function which accepts a single argument with browserify options and returns a new bundle:
+
+```javascript
+    browserify: {
+      createBrowserify: function(options) {
+        var browserify = require('browserify');
+        var bundle = browserify(options);
+        return bundle;
+      }
+    }
+```
+
 
 ### Watchify Config
 

--- a/lib/bro.js
+++ b/lib/bro.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var browserify = require('browserify'),
-    watchify = require('watchify'),
+var watchify = require('watchify'),
     convert = require('convert-source-map'),
     minimatch = require('minimatch'),
     escape = require('js-string-escape');
@@ -192,6 +191,9 @@ function Bro(bundleFile) {
     if ('watchify' in browserifyOptions) {
       log.warn('Configure watchify via config.watchify');
     }
+
+    // (no need to include our own browserify version if the user overrides it)
+    var browserify = bopts.createBrowserify || require('browserify');
 
     var w = browserify(browserifyOptions);
     w.setMaxListeners(Infinity);

--- a/test/spec/pluginSpec.js
+++ b/test/spec/pluginSpec.js
@@ -563,6 +563,41 @@ describe('karma-browserify', function() {
       });
     });
 
+    it('should support createBrowserify option', function(done) {
+
+      // given
+      var createdBundle;
+      var plugin = createPlugin({
+        browserify: {
+          createBrowserify: function(options) {
+            expect(options).to.be.ok;
+            expect(arguments.length).to.equal(1);
+            createdBundle = require('browserify')(options);
+            return createdBundle;
+          },
+          configure: function(bundle) {
+            expect(bundle).to.equal(createdBundle);
+            bundle.external('foobar');
+          }
+        }
+      });
+
+      var bundleFile = createFile(bundle.location);
+      var testFile = createFile('test/fixtures/configure.js');
+
+      // when
+      plugin.preprocess(bundleFile, [ testFile ], function() {
+
+        // then
+        // bundle got created
+        expect(createdBundle).to.be.ok;
+        expect(bundleFile.bundled).to.exist;
+        expect(bundleFile.bundled).to.contain('require(\'foobar\')');
+
+        done();
+      });
+    });
+
 
     it('should configure debug with source map support', function(done) {
 


### PR DESCRIPTION
This plugin uses browserify 10 which is unable to parse my project. Browserify 12 does work. 

Instead of having to update this plugin whenever a new major browserify version is released, it would be easier to let me specify the browserify version I would like to use. This would also let me pin browserify to a specify patch version in case of regressions (which I've actually suffered from using browserify a few times).