### PR TITLE
make peerDep semver more specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "watchify": "^3.6.1"
   },
   "peerDependencies": {
-    "karma": ">=0.10",
-    "browserify": ">=10 <=13",
-    "watchify": ">=3 <4"
+    "karma": ">=0.10.0",
+    "browserify": ">=10.0.0 <=13.0.0",
+    "watchify": ">=3.0.0 <4.0.0"
   }
 }


### PR DESCRIPTION
Addresses #164 

The discussion in that issue doesn't actually hit on the point of what's gone wrong. It appears the order version of `semver` in npm ~1.4.2x doesn't see `<=13` matching `13.0.0`. This can be tested with a simple one liner
```
npm install karma-browserify browserify@~13
```

This does in fact satisfy the peer dependency but an error is still raised. NPM may or may not fix the issue in that order version but at least this is a local fix that can prevent it.