### PR TITLE
feat(bro): add support for bundle wrappers

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -227,7 +227,11 @@ function Bro(bundleFile) {
 
     // test if we have a configure function
     if (bopts.configure && typeof bopts.configure === 'function') {
-      bopts.configure(w);
+      // allow usage of bundler wrappers, e.g. browserify-incremental
+      var configuredBrowserify = bopts.configure(w);
+      if (configuredBrowserify) {
+        w = configuredBrowserify;
+      }
     }
 
     // register rebuild bundle on change


### PR DESCRIPTION
Returning something in `configure` function will overwrite the current bundler. Related to #176 