### PR TITLE
Fix: make karma-browserify compatible with parcelify

### DIFF
--- a/lib/bro.js
+++ b/lib/bro.js
@@ -314,7 +314,7 @@ function Bro(bundleFile) {
 
       // add the file during next prebundle step
       w.once('prebundle', function() {
-        w.require('./' + relativePath, { expose: absolutePath });
+        w.add('./' + relativePath, { expose: absolutePath });
       });
 
       deferredBundle(function(err) {


### PR DESCRIPTION
I'd like to propose the following change in order to make [karma-browserify compatible with parcelify](https://github.com/nikku/karma-browserify/issues/175). Parcelify needs an explicit entrypoint to concatenated the CSS in the right order. karma-browserify thus should use `b.add` instead of `b.require` to bundle the specs. 

Unit tests still pass...