### PR TITLE
Fix peerDependency version of browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "peerDependencies": {
     "karma": ">=0.10.0",
-    "browserify": ">=10.0.0 <=13.0.0",
+    "browserify": ">=10.0.0 <14.0.0",
     "watchify": ">=3.0.0 <4.0.0"
   }
 }


### PR DESCRIPTION
`browserify` just published v13.0.1 and the version is not included in the peer dep range of this module.

But I think that was a mistake because originally the range was `>=10 <=13`, that should have been translated `>=10.0.0 <14.0.0`, but now it says `>=10.0.0 <=13.0.0`. This PR fixes that point.