### PR TITLE
[#190] Scenario: typescript compilation errors prevent test run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 tmp/
+.idea/

--- a/test/integration/karma.conf.js
+++ b/test/integration/karma.conf.js
@@ -25,7 +25,10 @@ module.exports = function(karma) {
       'test/*Spec.js',
 
       // a helper, accidently included with the tests
-      'test/helper.js'
+      'test/helper.js',
+
+      // tests written in typescript
+      'ts/*.spec.ts'
     ],
 
     reporters: [ 'dots' ],
@@ -33,7 +36,8 @@ module.exports = function(karma) {
     preprocessors: {
       'lib/a.js': [ 'browserify' ],
       'test/*Spec.js': [ 'browserify' ],
-      'test/helper.js': [ 'browserify' ]
+      'test/helper.js': [ 'browserify' ],
+      'ts/*.ts': [ 'browserify' ]
     },
 
     browsers: [ 'PhantomJS' ],
@@ -50,11 +54,13 @@ module.exports = function(karma) {
 
       // configure browserify
       configure: function(b) {
-
         b.on('prebundle', function() {
           b.external('lib/common.js');
         });
-      }
+      },
+      plugin: [
+        ['tsify']
+      ]
     }
   });
 };

--- a/test/integration/ts/A.spec.ts
+++ b/test/integration/ts/A.spec.ts
@@ -1,0 +1,21 @@
+import {A} from "./A";
+
+describe('TypeScript Class A', () => {
+    it('should instantiate a class', () => {
+      let instance:A = new A();
+      console.warn('this test should run despite the compilation errors!')
+      expect(instance).toBeDefined();
+    })
+  }
+)
+
+// uncomment following declarations, to make the typescript compile without errors
+// and you will see the test is then executed.
+/*
+declare class assert {
+  toBeDefined()
+}
+declare function expect(obj:any):assert
+declare function it(descrption:string, cb:Function)
+declare function describe(descrption:string, cb:Function)
+*/

--- a/test/integration/ts/A.ts
+++ b/test/integration/ts/A.ts
@@ -1,0 +1,7 @@
+export class A {
+  private time:Date;
+
+  constructor() {
+    this.time = new Date()
+  }
+}


### PR DESCRIPTION
Linked to https://github.com/nikku/karma-browserify/issues/190. 

Adds an integration test which shows: when there are typescript compilation errors, the tests are not run.
When the declarations are uncommented, the test is run because there are no typescript compilation errors.