### PR TITLE
Switch from PhantomJS to Chrome launcher

### DIFF
--- a/example/karma.conf.js
+++ b/example/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(karma) {
       'test/**/*Spec.js': [ 'browserify' ]
     },
 
-    browsers: [ 'PhantomJS' ],
+    browsers: [ 'Chrome' ],
 
     logLevel: 'LOG_DEBUG',
 

--- a/example/package.json
+++ b/example/package.json
@@ -18,8 +18,8 @@
     "browserify-shim": "^3.8.0",
     "karma": "^0.13.0",
     "karma-browserify": "^5.0.0",
+    "karma-chrome-launcher": "^2.1.1",
     "karma-jasmine": "^0.1.5",
-    "karma-phantomjs-launcher": "^0.1.4",
     "watchify": "^3.6.1"
   },
   "browserify-shim": {


### PR DESCRIPTION
Reasons against Phantom:

- **Most serious:** Tests passing in Phantom does not guarantee them passing in real browsers
- `PhantomJS` downloads its huge file into the `node_module` directory every time
- The installation breaks down on slow connections, and is not resumable without manual fixing
- Both `npm` and `yarn` do not clearly report the reason for delay is the `PhantomJS` installation, the user is left wondering what is going on
- The overhead is painful and inappropriate for quickly trying example like here
- The project [does not seem to be as actively maintained](https://github.com/ariya/phantomjs/graphs/contributors) with [almost 2000K open issues](https://github.com/ariya/phantomjs/issues)
- There are more modern alternatives such as [NightmareJS](https://github.com/segmentio/nightmare)

Reasons for the Chrome launcher:

- No massive download needed, the locally installed browser is used
- Installation is quick and painless, no broken pipes
- 100% reliable: your tests run exactly in the same browser as used by your users

Need I say more? :)

